### PR TITLE
Add centralized exception handling and validation problem details

### DIFF
--- a/PeaceDatabase.Tests/ExceptionHandlingTests.cs
+++ b/PeaceDatabase.Tests/ExceptionHandlingTests.cs
@@ -1,0 +1,164 @@
+using System;
+using System.Collections.Generic;
+using System.Net;
+using System.Net.Http;
+using System.Net.Http.Json;
+using System.Text;
+using System.Text.Json;
+using FluentAssertions;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using PeaceDatabase.Core.Models;
+using PeaceDatabase.Core.Services;
+using Xunit;
+
+namespace PeaceDatabase.Tests.Api;
+
+public class ExceptionHandlingTests : IClassFixture<WebApplicationFactory<Program>>
+{
+    private readonly WebApplicationFactory<Program> _factory;
+
+    public ExceptionHandlingTests(WebApplicationFactory<Program> factory)
+    {
+        _factory = factory;
+    }
+
+    [Fact]
+    public async Task Invalid_json_returns_validation_problem()
+    {
+        var client = _factory.CreateClient();
+        await client.PutAsync("/v1/db/app", content: null);
+
+        var response = await client.PostAsync("/v1/db/app/docs", new StringContent("{\"id\":", Encoding.UTF8, "application/json"));
+
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+        var problem = await ParseProblem(response);
+        problem.GetProperty("type").GetString().Should().Be("https://example.com/errors/validation");
+        problem.GetProperty("title").GetString().Should().Be("Malformed JSON payload");
+        problem.GetProperty("status").GetInt32().Should().Be(400);
+        problem.GetProperty("traceId").GetString().Should().NotBeNullOrWhiteSpace();
+        problem.GetProperty("errors").GetProperty("body").EnumerateArray().Should().ContainSingle();
+    }
+
+    [Fact]
+    public async Task Model_validation_returns_problem_details()
+    {
+        var client = _factory.CreateClient();
+        await client.PutAsync("/v1/db/app", content: null);
+
+        using var content = JsonContent.Create<object?>(null);
+        var response = await client.PostAsync("/v1/db/app/_find/fields", content);
+
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+        var problem = await ParseProblem(response);
+        problem.GetProperty("type").GetString().Should().Be("https://example.com/errors/validation");
+        problem.GetProperty("title").GetString().Should().Be("Request validation failed");
+        problem.GetProperty("errors").GetProperty("req").EnumerateArray().Should().NotBeEmpty();
+    }
+
+    [Fact]
+    public async Task Not_found_exception_returns_problem_details()
+    {
+        var client = _factory.CreateClient();
+        await client.PutAsync("/v1/db/app", content: null);
+
+        var response = await client.GetAsync("/v1/db/app/docs/missing-id");
+
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+        var problem = await ParseProblem(response);
+        problem.GetProperty("type").GetString().Should().Be("https://example.com/errors/not-found");
+        problem.GetProperty("title").GetString().Should().Be("Resource not found");
+    }
+
+    [Fact]
+    public async Task Conflict_exception_returns_problem_details()
+    {
+        var client = _factory.CreateClient();
+        await client.PutAsync("/v1/db/app", content: null);
+
+        var create = await client.PostAsJsonAsync("/v1/db/app/docs", new Document
+        {
+            Id = "conflict-doc",
+            Data = new Dictionary<string, object> { ["type"] = "note" }
+        });
+        create.StatusCode.Should().Be(HttpStatusCode.Created);
+        var created = await create.Content.ReadFromJsonAsync<Document>();
+        created.Should().NotBeNull();
+
+        var conflictPayload = new Document
+        {
+            Id = "conflict-doc",
+            Rev = "1-notarev",
+            Data = new Dictionary<string, object> { ["type"] = "note" }
+        };
+
+        var response = await client.PutAsJsonAsync("/v1/db/app/docs/conflict-doc", conflictPayload);
+
+        response.StatusCode.Should().Be(HttpStatusCode.Conflict);
+        var problem = await ParseProblem(response);
+        problem.GetProperty("type").GetString().Should().Be("https://example.com/errors/conflict");
+        problem.GetProperty("title").GetString().Should().Be("Operation conflict");
+    }
+
+    [Fact]
+    public async Task Unexpected_exception_returns_internal_problem()
+    {
+        await using var factory = new ThrowingWebApplicationFactory();
+        var client = factory.CreateClient();
+
+        var response = await client.PutAsync("/v1/db/app", content: null);
+
+        response.StatusCode.Should().Be(HttpStatusCode.InternalServerError);
+        var problem = await ParseProblem(response);
+        problem.GetProperty("type").GetString().Should().Be("https://example.com/errors/internal");
+        problem.GetProperty("title").GetString().Should().Be("Unexpected server error");
+        problem.TryGetProperty("detail", out var detail).Should().BeTrue();
+        detail.ValueKind.Should().Be(JsonValueKind.Null);
+        problem.GetProperty("traceId").GetString().Should().NotBeNullOrWhiteSpace();
+    }
+
+    private static async Task<JsonElement> ParseProblem(HttpResponseMessage response)
+    {
+        var payload = await response.Content.ReadAsStringAsync();
+        using var json = JsonDocument.Parse(payload);
+        return json.RootElement;
+    }
+
+    private sealed class ThrowingWebApplicationFactory : WebApplicationFactory<Program>
+    {
+        protected override void ConfigureWebHost(Microsoft.AspNetCore.Hosting.IWebHostBuilder builder)
+        {
+            builder.ConfigureServices(services =>
+            {
+                services.RemoveAll<IDocumentService>();
+                services.AddSingleton<IDocumentService, ThrowingDocumentService>();
+            });
+        }
+    }
+
+    private sealed class ThrowingDocumentService : IDocumentService
+    {
+        public (bool Ok, string? Error) CreateDb(string db) => throw new InvalidOperationException("boom");
+
+        public (bool Ok, string? Error) DeleteDb(string db) => throw new InvalidOperationException("boom");
+
+        public Document? Get(string db, string id, string? rev = null) => throw new InvalidOperationException("boom");
+
+        public (bool Ok, Document? Doc, string? Error) Put(string db, Document doc) => throw new InvalidOperationException("boom");
+
+        public (bool Ok, Document? Doc, string? Error) Post(string db, Document doc) => throw new InvalidOperationException("boom");
+
+        public (bool Ok, string? Error) Delete(string db, string id, string rev) => throw new InvalidOperationException("boom");
+
+        public IEnumerable<Document> AllDocs(string db, int skip = 0, int limit = 1000, bool includeDeleted = true) => throw new InvalidOperationException("boom");
+
+        public int Seq(string db) => throw new InvalidOperationException("boom");
+
+        public IEnumerable<Document> FindByFields(string db, IDictionary<string, string>? equals = null, (string field, double? min, double? max)? numericRange = null, int skip = 0, int limit = 100) => throw new InvalidOperationException("boom");
+
+        public IEnumerable<Document> FindByTags(string db, IEnumerable<string>? allOf = null, IEnumerable<string>? anyOf = null, IEnumerable<string>? noneOf = null, int skip = 0, int limit = 100) => throw new InvalidOperationException("boom");
+
+        public IEnumerable<Document> FullTextSearch(string db, string query, int skip = 0, int limit = 100) => throw new InvalidOperationException("boom");
+    }
+}

--- a/PeaceDatabase/Controllers/ControllerErrorMapper.cs
+++ b/PeaceDatabase/Controllers/ControllerErrorMapper.cs
@@ -1,0 +1,102 @@
+using System;
+using System.Collections.Generic;
+using PeaceDatabase.Core.Models;
+using PeaceDatabase.WebApi.Exceptions;
+
+namespace PeaceDatabase.WebApi.Controllers;
+
+/// <summary>
+/// Central place where service error messages are translated into domain-specific exceptions.
+/// Extend <see cref="MapException"/> when new storage implementations introduce new messages.
+/// </summary>
+internal static class ControllerErrorMapper
+{
+    public static void ThrowIfFailed((bool Ok, string? Error) result, string db, string? id = null)
+    {
+        if (result.Ok)
+        {
+            return;
+        }
+
+        throw MapException(result.Error, db, id);
+    }
+
+    public static Document EnsureDocument((bool Ok, Document? Doc, string? Error) result, string db, string? id = null)
+    {
+        if (!result.Ok)
+        {
+            throw MapException(result.Error, db, id);
+        }
+
+        return result.Doc ?? throw new InvalidOperationException("Operation succeeded but did not return a document.");
+    }
+
+    private static Exception MapException(string? error, string db, string? id)
+    {
+        _ = id; // reserved for future mapping rules that may rely on resource identifiers.
+        if (string.IsNullOrWhiteSpace(error))
+        {
+            return new InvalidOperationException("Operation failed without error details.");
+        }
+
+        var normalized = error.Trim();
+        var lower = normalized.ToLowerInvariant();
+
+        if (lower.Contains("not found", StringComparison.Ordinal))
+        {
+            return new ResourceNotFoundException(normalized);
+        }
+
+        if (lower.Contains("conflict", StringComparison.Ordinal))
+        {
+            return new ConflictException(normalized);
+        }
+
+        if (lower.Contains("missing _id", StringComparison.Ordinal))
+        {
+            return new DomainValidationException(
+                "Request validation failed",
+                new Dictionary<string, string[]>
+                {
+                    ["_id"] = new[] { "The _id field is required." }
+                });
+        }
+
+        if (lower.Contains("missing _rev", StringComparison.Ordinal))
+        {
+            return new DomainValidationException(
+                "Request validation failed",
+                new Dictionary<string, string[]>
+                {
+                    ["_rev"] = new[] { "The _rev field is required." }
+                });
+        }
+
+        if (lower.Contains("new document must not provide _rev", StringComparison.Ordinal))
+        {
+            return new DomainValidationException(
+                "Request validation failed",
+                new Dictionary<string, string[]>
+                {
+                    ["_rev"] = new[] { "A new document must not specify _rev." }
+                });
+        }
+
+        if (lower.Contains("bad database name", StringComparison.Ordinal))
+        {
+            return new DomainValidationException(
+                "Request validation failed",
+                new Dictionary<string, string[]>
+                {
+                    ["db"] = new[] { normalized }
+                });
+        }
+
+        if (lower.Contains("database not found", StringComparison.Ordinal))
+        {
+            return new ResourceNotFoundException($"Database '{db}' was not found.");
+        }
+
+        return new InvalidOperationException(normalized);
+    }
+}

--- a/PeaceDatabase/WebApi/Exceptions/ConflictException.cs
+++ b/PeaceDatabase/WebApi/Exceptions/ConflictException.cs
@@ -1,0 +1,26 @@
+using System;
+using System.Runtime.Serialization;
+
+namespace PeaceDatabase.WebApi.Exceptions;
+
+/// <summary>
+/// Represents a conflicting state detected during a request.
+/// </summary>
+[Serializable]
+public sealed class ConflictException : Exception
+{
+    public ConflictException(string message)
+        : base(message)
+    {
+    }
+
+    public ConflictException(string message, Exception? innerException)
+        : base(message, innerException)
+    {
+    }
+
+    private ConflictException(SerializationInfo info, StreamingContext context)
+        : base(info, context)
+    {
+    }
+}

--- a/PeaceDatabase/WebApi/Exceptions/DomainValidationException.cs
+++ b/PeaceDatabase/WebApi/Exceptions/DomainValidationException.cs
@@ -1,0 +1,50 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.Serialization;
+
+namespace PeaceDatabase.WebApi.Exceptions;
+
+/// <summary>
+/// Represents a domain validation failure that should result in a 400 response.
+/// </summary>
+[Serializable]
+public sealed class DomainValidationException : Exception
+{
+    public IReadOnlyDictionary<string, string[]> Errors { get; }
+
+    public DomainValidationException(string message)
+        : this(message, null, null)
+    {
+    }
+
+    public DomainValidationException(string message, IDictionary<string, string[]>? errors)
+        : this(message, errors, null)
+    {
+    }
+
+    public DomainValidationException(string message, IDictionary<string, string[]>? errors, Exception? innerException)
+        : base(message, innerException)
+    {
+        Errors = errors != null
+            ? new Dictionary<string, string[]>(errors, StringComparer.OrdinalIgnoreCase)
+            : new Dictionary<string, string[]>(StringComparer.OrdinalIgnoreCase);
+    }
+
+    private DomainValidationException(SerializationInfo info, StreamingContext context)
+        : base(info, context)
+    {
+        Errors = (info.GetValue(nameof(Errors), typeof(Dictionary<string, string[]>)) as Dictionary<string, string[]>)
+                 ?? new Dictionary<string, string[]>(StringComparer.OrdinalIgnoreCase);
+    }
+
+    public override void GetObjectData(SerializationInfo info, StreamingContext context)
+    {
+        ArgumentNullException.ThrowIfNull(info);
+        var payload = Errors is Dictionary<string, string[]> dict
+            ? dict
+            : Errors.ToDictionary(k => k.Key, v => v.Value, StringComparer.OrdinalIgnoreCase);
+        info.AddValue(nameof(Errors), payload);
+        base.GetObjectData(info, context);
+    }
+}

--- a/PeaceDatabase/WebApi/Exceptions/ResourceNotFoundException.cs
+++ b/PeaceDatabase/WebApi/Exceptions/ResourceNotFoundException.cs
@@ -1,0 +1,26 @@
+using System;
+using System.Runtime.Serialization;
+
+namespace PeaceDatabase.WebApi.Exceptions;
+
+/// <summary>
+/// Thrown when a requested resource cannot be located.
+/// </summary>
+[Serializable]
+public sealed class ResourceNotFoundException : Exception
+{
+    public ResourceNotFoundException(string message)
+        : base(message)
+    {
+    }
+
+    public ResourceNotFoundException(string message, Exception? innerException)
+        : base(message, innerException)
+    {
+    }
+
+    private ResourceNotFoundException(SerializationInfo info, StreamingContext context)
+        : base(info, context)
+    {
+    }
+}

--- a/PeaceDatabase/WebApi/Exceptions/UnauthorizedOperationException.cs
+++ b/PeaceDatabase/WebApi/Exceptions/UnauthorizedOperationException.cs
@@ -1,0 +1,41 @@
+using System;
+using System.Runtime.Serialization;
+
+namespace PeaceDatabase.WebApi.Exceptions;
+
+/// <summary>
+/// Represents an operation that cannot be performed due to missing authentication or authorization.
+/// </summary>
+[Serializable]
+public sealed class UnauthorizedOperationException : Exception
+{
+    /// <summary>
+    /// When true the caller is not authenticated (401). Otherwise forbidden (403).
+    /// </summary>
+    public bool RequiresAuthentication { get; }
+
+    public UnauthorizedOperationException(string message, bool requiresAuthentication = false)
+        : base(message)
+    {
+        RequiresAuthentication = requiresAuthentication;
+    }
+
+    public UnauthorizedOperationException(string message, bool requiresAuthentication, Exception? innerException)
+        : base(message, innerException)
+    {
+        RequiresAuthentication = requiresAuthentication;
+    }
+
+    private UnauthorizedOperationException(SerializationInfo info, StreamingContext context)
+        : base(info, context)
+    {
+        RequiresAuthentication = info.GetBoolean(nameof(RequiresAuthentication));
+    }
+
+    public override void GetObjectData(SerializationInfo info, StreamingContext context)
+    {
+        ArgumentNullException.ThrowIfNull(info);
+        info.AddValue(nameof(RequiresAuthentication), RequiresAuthentication);
+        base.GetObjectData(info, context);
+    }
+}

--- a/PeaceDatabase/WebApi/Middleware/ExceptionHandlingMiddleware.cs
+++ b/PeaceDatabase/WebApi/Middleware/ExceptionHandlingMiddleware.cs
@@ -1,0 +1,177 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Text.Json;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Infrastructure;
+using Microsoft.Extensions.Logging;
+using PeaceDatabase.WebApi.Exceptions;
+
+namespace PeaceDatabase.WebApi.Middleware;
+
+/// <summary>
+/// Centralized exception handling middleware that converts exceptions into RFC 7807 <see cref="ProblemDetails"/> responses.
+/// The mapping is intentionally compact so new exception types can be added by extending <see cref="MapException"/>.
+/// </summary>
+public sealed class ExceptionHandlingMiddleware : IMiddleware
+{
+    private static readonly Uri ValidationType = new("https://example.com/errors/validation");
+    private static readonly Uri DomainValidationType = new("https://example.com/errors/domain-validation");
+    private static readonly Uri NotFoundType = new("https://example.com/errors/not-found");
+    private static readonly Uri ConflictType = new("https://example.com/errors/conflict");
+    private static readonly Uri UnauthorizedType = new("https://example.com/errors/unauthorized");
+    private static readonly Uri ForbiddenType = new("https://example.com/errors/forbidden");
+    private static readonly Uri InternalType = new("https://example.com/errors/internal");
+
+    private readonly ILogger<ExceptionHandlingMiddleware> _logger;
+    private readonly ProblemDetailsFactory _problemDetailsFactory;
+
+    public ExceptionHandlingMiddleware(ILogger<ExceptionHandlingMiddleware> logger, ProblemDetailsFactory problemDetailsFactory)
+    {
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        _problemDetailsFactory = problemDetailsFactory ?? throw new ArgumentNullException(nameof(problemDetailsFactory));
+    }
+
+    public async Task InvokeAsync(HttpContext context, RequestDelegate next)
+    {
+        try
+        {
+            await next(context);
+        }
+        catch (Exception ex)
+        {
+            await HandleExceptionAsync(context, ex);
+        }
+    }
+
+    public Task HandleExceptionAsync(HttpContext context, Exception? exception)
+    {
+        if (context.Response.HasStarted)
+        {
+            _logger.LogWarning("Cannot write problem response because the response has already started for {Path}", context.Request.Path);
+            return Task.CompletedTask;
+        }
+
+        var traceId = Activity.Current?.Id ?? context.TraceIdentifier;
+
+        var mapping = MapException(exception);
+        var problem = _problemDetailsFactory.CreateProblemDetails(
+            context,
+            statusCode: mapping.StatusCode,
+            title: mapping.Title,
+            type: mapping.Type.ToString(),
+            detail: mapping.Detail);
+
+        problem.Extensions["traceId"] = traceId;
+
+        if (mapping.Errors?.Count > 0)
+        {
+            problem.Extensions["errors"] = mapping.Errors;
+        }
+
+        context.Response.Clear();
+        context.Response.StatusCode = mapping.StatusCode;
+        context.Response.ContentType = "application/problem+json";
+
+        LogException(mapping.LogLevel, context, exception, traceId);
+
+        return context.Response.WriteAsJsonAsync(problem);
+    }
+
+    private (int StatusCode, Uri Type, string Title, string? Detail, IDictionary<string, string[]>? Errors, LogLevel LogLevel) MapException(Exception? exception)
+    {
+        if (exception is null)
+        {
+            return (StatusCodes.Status500InternalServerError, InternalType, "Unexpected server error", null, null, LogLevel.Error);
+        }
+
+        return exception switch
+        {
+            DomainValidationException dve => (
+                StatusCodes.Status400BadRequest,
+                DomainValidationType,
+                "Domain validation failed",
+                dve.Message,
+                dve.Errors.Count > 0 ? dve.Errors : null,
+                LogLevel.Warning),
+
+            ResourceNotFoundException rnf => (
+                StatusCodes.Status404NotFound,
+                NotFoundType,
+                "Resource not found",
+                rnf.Message,
+                null,
+                LogLevel.Information),
+
+            ConflictException conflict => (
+                StatusCodes.Status409Conflict,
+                ConflictType,
+                "Operation conflict",
+                conflict.Message,
+                null,
+                LogLevel.Warning),
+
+            UnauthorizedOperationException unauthorized => (
+                unauthorized.RequiresAuthentication ? StatusCodes.Status401Unauthorized : StatusCodes.Status403Forbidden,
+                unauthorized.RequiresAuthentication ? UnauthorizedType : ForbiddenType,
+                unauthorized.RequiresAuthentication ? "Authentication required" : "Operation is forbidden",
+                unauthorized.Message,
+                null,
+                LogLevel.Warning),
+
+            JsonException => BuildValidationResult("Malformed JSON payload", "body", "The request body contains invalid JSON."),
+            FormatException => BuildValidationResult("Request validation failed", "body", "The request payload format is invalid."),
+            ArgumentException arg => BuildValidationResult("Request validation failed", arg.ParamName ?? "argument", arg.Message),
+
+            // HTTP 499 is non-standard but supported by Kestrel. It reflects a cancelled request without blaming the server.
+            OperationCanceledException => (
+                StatusCodes.Status499ClientClosedRequest,
+                ValidationType,
+                "Request was cancelled",
+                "The operation was cancelled by the caller.",
+                null,
+                LogLevel.Information),
+
+            _ => (
+                StatusCodes.Status500InternalServerError,
+                InternalType,
+                "Unexpected server error",
+                null,
+                null,
+                LogLevel.Error)
+        };
+    }
+
+    private static (int StatusCode, Uri Type, string Title, string? Detail, IDictionary<string, string[]>? Errors, LogLevel LogLevel) BuildValidationResult(string title, string key, string message)
+    {
+        var errors = new Dictionary<string, string[]>(StringComparer.OrdinalIgnoreCase)
+        {
+            [key] = new[] { message }
+        };
+        return (
+            StatusCodes.Status400BadRequest,
+            ValidationType,
+            title,
+            message,
+            errors,
+            LogLevel.Warning);
+    }
+
+    private void LogException(LogLevel level, HttpContext context, Exception? exception, string traceId)
+    {
+        var payload = exception?.ToString() ?? "(no exception)";
+        if (payload.Length > 2048)
+        {
+            payload = payload[..2048] + "…";
+        }
+
+        _logger.Log(level,
+            "Handled exception {ExceptionType} for {Method} {Path} with trace {TraceId}. Details: {Details}",
+            exception?.GetType().Name ?? "Unknown",
+            context.Request.Method,
+            context.Request.Path,
+            traceId,
+            payload);
+    }
+}

--- a/README.MD
+++ b/README.MD
@@ -84,6 +84,69 @@
 
 ---
 
+## Ошибки API
+
+Все ошибки возвращаются в формате RFC 7807 (`application/problem+json`).
+Полезные поля:
+
+- `type` — URI категории ошибки из пространства `https://example.com/errors/*`.
+- `title` — краткое описание.
+- `status` — HTTP-статус.
+- `traceId` — идентификатор запроса (совместим с Activity/Logging).
+- `errors` — словарь `поле → сообщения` (для валидационных сценариев).
+
+Примеры ответов:
+
+**400 (валидация)**
+
+```json
+{
+  "type": "https://example.com/errors/validation",
+  "title": "Request validation failed",
+  "status": 400,
+  "traceId": "00-<guid>-<span>-01",
+  "errors": {
+    "name": ["The Name field is required.", "The Name length must be between 1 and 64."],
+    "age": ["The field Age must be between 1 and 120."]
+  }
+}
+```
+
+**404 (ресурс не найден)**
+
+```json
+{
+  "type": "https://example.com/errors/not-found",
+  "title": "Resource not found",
+  "status": 404,
+  "traceId": "00-<guid>-<span>-01"
+}
+```
+
+**409 (конфликт)**
+
+```json
+{
+  "type": "https://example.com/errors/conflict",
+  "title": "Operation conflict",
+  "status": 409,
+  "traceId": "00-<guid>-<span>-01"
+}
+```
+
+**500 (внутренняя ошибка)**
+
+```json
+{
+  "type": "https://example.com/errors/internal",
+  "title": "Unexpected server error",
+  "status": 500,
+  "traceId": "00-<guid>-<span>-01"
+}
+```
+
+---
+
 ## Планы
 
 - Дисковое и LSM-хранилище.


### PR DESCRIPTION
## Summary
- add a reusable exception handling middleware that maps domain and infrastructure failures to RFC 7807 problem details
- introduce typed domain exceptions and shared controller helpers to keep controllers lean while emitting consistent errors
- adjust controllers and Program pipeline configuration to use the new handling, plus document the error contract in the README
- cover the scenarios with new integration tests for validation, not found, conflict, and unexpected failures

## Testing
- `dotnet test PeaceDatabase/PeaceDatabase.sln` *(fails: dotnet CLI is unavailable in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e3f44f0c548333946d3022116b6b77